### PR TITLE
rename method: var to renderVariables

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -7,7 +7,7 @@ class DisplayJS {
 		this.obj = obj;
 	}
 	// DOM manipulation and browser API.
-	var(push) {
+	renderVariables(push) {
 		const var_push = () => {
 			this.if();
 			this.else();
@@ -40,7 +40,7 @@ class DisplayJS {
 	xssURI(str) {
 		return encodeURI(str);
 	}
-	target(callback= () => { this.var(); }) {
+	target(callback= () => { this.renderVariables(); }) {
 		const addEventListener = ((() => {
 			if (document.addEventListener) {
 				return (element, event, handler) => {

--- a/src/display.js
+++ b/src/display.js
@@ -7,7 +7,7 @@ class DisplayJS {
 		this.obj = obj;
 	}
 	// DOM manipulation and browser API.
-	renderVariables(push) {
+	var(push) {
 		const var_push = () => {
 			this.if();
 			this.else();
@@ -30,6 +30,12 @@ class DisplayJS {
 			}, push);
 		}
 	}
+	render (push) {
+		this.var(push)
+	}
+	renderVariables (push) {
+		this.var(push)
+	}
 	xss (str) {
 		const lt = /</g;
 		const gt = />/g;
@@ -40,7 +46,7 @@ class DisplayJS {
 	xssURI(str) {
 		return encodeURI(str);
 	}
-	target(callback= () => { this.renderVariables(); }) {
+	target(callback= () => { this.var(); }) {
 		const addEventListener = ((() => {
 			if (document.addEventListener) {
 				return (element, event, handler) => {


### PR DESCRIPTION
var is a confusing method name. 'var' is used to declare a variable in Javascript, and to avoid confusion it's better not to use that name for anything else.