### PR TITLE
Check "global" variable

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -778,6 +778,6 @@ if (typeof define === "function" && define.amd) {
 	}
 		// But always support CommonJS module 1.1.1 spec (`exports` cannot be a function)
 	exports.DisplayJS = new DisplayJS;
-} else {
+} else if (typeof global !== "undefined") {
 	global.DisplayJS = new DisplayJS;
 }


### PR DESCRIPTION
LinuxMint 18.2 (x32) - Chromium 60.
Error: "global" is not defined.