### PR TITLE
Fix link of 'jquery.com'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@
                 <header>
                     <h1>DisplayJS</h1>
                     <hr>
-                    <p>DisplayJS is a simple framework that helps you to efficiently render the DOM. When you need to display the content of a variable on the page, you'll write something like this, if you're using <a href="jquery.com">jQuery</a>:</p>
+                    <p>DisplayJS is a simple framework that helps you to efficiently render the DOM. When you need to display the content of a variable on the page, you'll write something like this, if you're using <a href="https://jquery.com">jQuery</a>:</p>
                     <script src="https://gist.github.com/arguiot/2a238f6e26436c3e0e50b1995a09749e.js"></script>
                     <p>When you just have one or two variable to display, it's fine to use this method, but when you have like 20 or 30 variables to display, it become a big mess. That's why I created DisplayJS</p>
                     <p>Now, you can simply use the Display JS method:</p>


### PR DESCRIPTION
The origin link href="jquery.com" brings me to "https://display.js.org/jquery.com", which is wrong.
Just fix it.